### PR TITLE
A fix to x86 and x64 problems

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,14 @@ jobs:
 
       - name: Setup Lime
         run: |
+        
           haxelib run lime setup -alias -y
+          # This is just a test fix, i'm testing in my pc, compiling in cmd,
+          # and the build its working without "-d no precompiled headers" command
+          
+          # But... I didn't tested this in a mobile x86 phone kek
+          haxelib run lime config HXCPP_ARM64 true
+          haxelib run lime config HXCPP_x86 true
           haxelib run lime config ANDROID_SDK $ANDROID_HOME
           haxelib run lime config ANDROID_NDK_ROOT $ANDROID_NDK_HOME
           haxelib run lime config JAVA_HOME $JAVA_HOME


### PR DESCRIPTION
In my tests, that worked without build commands:

"-D NO_PRECOMPILED_HEADERS" and "-D HXCPP_VERBOSE"